### PR TITLE
Allow more complex parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Show blame view of current file:
 :Tig! blame
 ```
 
+You can also manually craft tig commands by using variable expansion:
+
+* `%` will expand to the current file path
+* `+` will expand to the current line number (prefixed with `+` so that tig
+  will jump to that line)
+
+```
+:Tig! blame +
+:Tig blame + -- %
+```
+(These two actually result in the same tig command line being executed.)
+
 Configuration
 -------------
 Tig executable: `let g:tig_executable = 'tig'`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Show commit log of current file:
 :Tig!
 ```
 
+Show blame view of current file:
+```
+:Tig! blame
+```
+
 Configuration
 -------------
 Tig executable: `let g:tig_executable = 'tig'`

--- a/plugin/tig.vim
+++ b/plugin/tig.vim
@@ -31,14 +31,19 @@ if has('nvim')
       call termopen(g:tig_executable . ' ' . a:arg, s:callback)
     endfunction
 
-    exec g:tig_open_command
-    if a:bang > 0
-      call s:tigopen(current)
-    elseif a:0 > 0
-      call s:tigopen(a:1)
-    else
-      call s:tigopen(g:tig_default_command)
+    let arg = ''
+    if a:0 > 0
+      let arg .= ' ' . a:1
     endif
+    if a:bang > 0
+      let arg .= ' -- ' . current
+    endif
+    if len(arg) == 0
+      let arg = g:tig_default_command
+    endif
+
+    exec g:tig_open_command
+    call s:tigopen(arg)
     setlocal nonumber
     setlocal norelativenumber
     setlocal signcolumn=no

--- a/plugin/tig.vim
+++ b/plugin/tig.vim
@@ -33,7 +33,10 @@ if has('nvim')
 
     let arg = ''
     if a:0 > 0
-      let arg .= ' ' . a:1
+      let args = a:1
+      let args = substitute(args, '%', current, '')
+      let args = substitute(args, '+', '+' . line('.'), '')
+      let arg .= ' ' . args
     endif
     if a:bang > 0
       let arg .= ' -- ' . current


### PR DESCRIPTION
This will allow to combine the bang command with additional parameters and also include placeholders `%` and `+` in your command parameters that will be expanded into the current file path and the cursor's line number.

This way, you can create all kinds of calls to tig like:

* `Tig! blame +` to get a blame view of the current file with the current line highlighted
* `Tig! main --first-parent` get a list of all direct commits to the current file on the current branch

The file name placeholder expansion is a bit redundant with the bang command version but I just included it so maybe some specific uses that require a more complex command setup might work.